### PR TITLE
Add ufraw and ufraw-batch to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ RUN \
     curl \
     libimage-exiftool-perl \
     ffmpeg \
+    ufraw \
+    ufraw-batch \
     git \
     composer && \
     cd /var/www/html && \


### PR DESCRIPTION
ufraw and ufraw-batch are needed to convert raw files