### PR TITLE
Prevent 60s timeout of processing step

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -24,7 +24,8 @@ http {
     # By default, if the processing of images takes more than 60s,
     # a 504 Gateway timeout occurs, so we increase the timeout here
     # to allow procesing of large images or when multiple images are
-    # being processed at the same time
+    # being processed at the same time. We set max_execution_time
+    # below to the same value.
     fastcgi_read_timeout 3600;
 
     gzip  on;
@@ -79,7 +80,7 @@ http {
             fastcgi_index index.php;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_param PHP_VALUE "post_max_size=100M
-                max_execution_time=200
+                max_execution_time=3600
                 upload_max_filesize=20M
                 memory_limit=256M";
             fastcgi_param PATH /usr/local/bin:/usr/bin:/bin;

--- a/default.conf
+++ b/default.conf
@@ -21,6 +21,12 @@ http {
     sendfile        on;
     keepalive_timeout  65;
 
+    # By default, if the processing of images takes more than 60s,
+    # a 504 Gateway timeout occurs, so we increase the timeout here
+    # to allow procesing of large images or when multiple images are
+    # being processed at the same time
+    fastcgi_read_timeout 3600;
+
     gzip  on;
 
     server {

--- a/default.conf
+++ b/default.conf
@@ -28,6 +28,10 @@ http {
     # below to the same value.
     fastcgi_read_timeout 3600;
 
+    # We also set the send timeout since this can otherwise also cause
+    # issues with slow connections
+    fastcgi_send_timeout 3600;
+
     gzip  on;
 
     server {


### PR DESCRIPTION
This fixes https://github.com/LycheeOrg/Lychee/issues/637 - I wasn't sure what the best value would be to increase this to so increased it to an hour which should be plenty (!). It could be made shorter, but in that case the lychee UI would need to explicitly give an error about the processing taking too long rather than an unknown failure. I also updated the max execution time to match since it matters too.