### PR TITLE
Install libraw as a replacement for ufraw

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ RUN \
     curl \
     libimage-exiftool-perl \
     ffmpeg \
+    libraw20 \
+    libraw-bin \
     git \
     jpegoptim \
     optipng \


### PR DESCRIPTION
Not sure whether this will work. There's a testing image available at `lycheeorg/lychee:gha-libraw`. Feedback welcome!