### PR TITLE
add php7.4-intl for ARM64 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN \
     php7.4-fpm \
     php7.4-redis \
     php7.4-bcmath \
+    php7.4-intl \
     curl \
     libimage-exiftool-perl \
     ffmpeg \


### PR DESCRIPTION
Without `php7.4-intl` composer in the ARM64 build doesn't run correctly. It doesn't produce an actual error, so the RUN line moves along, but the resulting image isn't usable. 

```
Installing dependencies from lock file
Verifying lock file contents can be installed on current platform.
Your lock file does not contain a compatible set of packages. Please run composer update.

  Problem 1
    - beberlei/assert is locked to version v3.3.0 and an update of this package was not requested.
    - beberlei/assert v3.3.0 requires ext-intl * -> it is missing from your system. Install or enable PHP's intl extension.
  Problem 2
    - beberlei/assert v3.3.0 requires ext-intl * -> it is missing from your system. Install or enable PHP's intl extension.
    - web-auth/metadata-service v3.3.4 requires beberlei/assert ^3.2 -> satisfiable by beberlei/assert[v3.3.0].
    - web-auth/metadata-service is locked to version v3.3.4 and an update of this package was not requested.

To enable extensions, verify that they are enabled in your .ini files:
    - /etc/php/7.4/cli/php.ini
    - /etc/php/7.4/cli/conf.d/10-mysqlnd.ini
    - /etc/php/7.4/cli/conf.d/10-opcache.ini
    - /etc/php/7.4/cli/conf.d/10-pdo.ini
    - /etc/php/7.4/cli/conf.d/15-xml.ini
    - /etc/php/7.4/cli/conf.d/20-bcmath.ini
    - /etc/php/7.4/cli/conf.d/20-calendar.ini
    - /etc/php/7.4/cli/conf.d/20-ctype.ini
    - /etc/php/7.4/cli/conf.d/20-dom.ini
 ```

Adding the `php7.4-intl` package fixes the problem, as composer runs correctly when it is added. 
