### PR TITLE
Add include for custom Nginx configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Instead, we recommend to use the `PHP_VALUE` directive of PHP-FPM to override sp
 4. Add or change any other parameters (e.g. `client_max_body_size`)
 5. Mount your new file to `/etc/nginx/nginx.conf`
 
+If you just need to define extra Nginx directives, you mount those into /etc/nginx/conf.d/custom.conf.
+
 [arm64-shield]: https://img.shields.io/badge/arm64-yes-success.svg?style=flat
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-success.svg?style=flat
 [armv6-shield]: https://img.shields.io/badge/armv6-partial-yellow.svg?style=flat

--- a/default.conf
+++ b/default.conf
@@ -89,5 +89,7 @@ http {
         location ~ [^/]\.php(/|$) {
             return 403;
         }
+
+        include /etc/nginx/conf.d/custom.conf;
     }
 }


### PR DESCRIPTION
Add an include to nginx.conf, so you can add custom nginx directives (redirects from human-readable name to album id etc.) without completely overwriting it. The reason for this is, that overwriting nginx.conf breaks whenever Lychee switches to newer PHP (or any other major change in the configuration).