### PR TITLE
Create alpha releases

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -71,6 +71,89 @@ jobs:
           tags: |
             lycheeorg/lychee:testing-${{ github.run_id }}-devtools
 
+  alpha:
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Check if alpha exists
+        run: |
+          echo "EXISTS=$(git ls-remote --heads https://github.com/LycheeOrg/Lychee refs/heads/alpha | wc -l") >> $GITHUB_OUTPUT
+        if: alpha_exists
+      -
+        name: Checkout
+        if: ${{ steps.alpha_exists.outputs.EXISTS == '1' }}
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        if: ${{ steps.alpha_exists.outputs.EXISTS == '1' }}
+        uses: docker/setup-qemu-action@v3.0.0
+      -
+        name: Set up Docker Buildx
+        if: ${{ steps.alpha_exists.outputs.EXISTS == '1' }}
+        uses: docker/setup-buildx-action@v3.0.0
+      -
+        name: Login to DockerHub
+        if: ${{ steps.alpha_exists.outputs.EXISTS == '1' }}
+        uses: docker/login-action@v3.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v5.1.0
+        if: ${{ steps.alpha_exists.outputs.EXISTS == '1' }}
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: true
+          build-args: |
+            BRANCH=alpha
+          tags: |
+            lycheeorg/lychee:testing-${{ github.run_id }}-alpha
+
+  alpha-devtools:
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Check if alpha exists
+        run: |
+          echo "EXISTS=$(git ls-remote --heads https://github.com/LycheeOrg/Lychee refs/heads/alpha | wc -l") >> $GITHUB_OUTPUT
+        if: alpha_exists
+      -
+        name: Checkout
+        if: ${{ steps.alpha_exists.outputs.EXISTS == '1' }}
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        if: ${{ steps.alpha_exists.outputs.EXISTS == '1' }}
+        uses: docker/setup-qemu-action@v3.0.0
+      -
+        name: Set up Docker Buildx
+        if: ${{ steps.alpha_exists.outputs.EXISTS == '1' }}
+        uses: docker/setup-buildx-action@v3.0.0
+      -
+        name: Login to DockerHub
+        if: ${{ steps.alpha_exists.outputs.EXISTS == '1' }}
+        uses: docker/login-action@v3.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v5.1.0
+        if: ${{ steps.alpha_exists.outputs.EXISTS == '1' }}
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: true
+          build-args: |
+            BRANCH=alpha
+            COMPOSER_NO_DEV=0
+          tags: |
+            lycheeorg/lychee:testing-${{ github.run_id }}-alpha-devtools
+
   default-env:
     needs: multiarch
     runs-on: ubuntu-latest
@@ -205,3 +288,5 @@ jobs:
           crane tag lycheeorg/lychee:testing-${{ github.run_id }} nightly
           crane cp lycheeorg/lychee:testing-${{ github.run_id }} lycheeorg/lychee-laravel:dev
           crane tag lycheeorg/lychee:testing-${{ github.run_id }}-devtools devtools
+          crane tag lycheeorg/lychee:testing-${{ github.run_id }}-alpha alpha
+          crane tag lycheeorg/lychee:testing-${{ github.run_id }}-alpha-devtools alpha-devtools

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -1,0 +1,131 @@
+name: Build and Push Alpha
+
+on:
+  workflow_dispatch:
+
+env:
+  PUID: '1000'
+  PGID: '1000'
+  PHP_TZ: 'UTC'
+
+jobs:
+  multiarch:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.0.0
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v3.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v5.1.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: true
+          build-args: |
+            BRANCH=alpha
+          tags: |
+            lycheeorg/lychee:testing-${{ github.run_id }}
+
+  default-env:
+    needs: multiarch
+    runs-on: ubuntu-latest
+    services:
+      lychee-docker:
+        image: lycheeorg/lychee:testing-${{ github.run_id }}
+        ports:
+          - 80:80
+    steps:
+      -
+        name: GET
+        run: 'curl -sSw "%{stderr}%{http_code}" http://localhost/ > /dev/null && curl -f http://localhost/'
+
+  sqlite:
+    needs: multiarch
+    runs-on: ubuntu-latest
+    services:
+      lychee-docker:
+        image: lycheeorg/lychee:testing-${{ github.run_id }}
+        ports:
+          - 80:80
+    env:
+      DB_CONNECTION: sqlite
+    steps:
+      -
+        name: GET
+        run: 'curl -sSw "%{stderr}%{http_code}" http://localhost/ > /dev/null && curl -f http://localhost/'
+
+  mysql:
+    needs: multiarch
+    runs-on: ubuntu-latest
+    services:
+      lychee-docker:
+        image: lycheeorg/lychee:testing-${{ github.run_id }}
+        ports:
+          - 80:80
+      db:
+        image: mariadb:latest
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: lychee
+    env:
+      DB_CONNECTION: mysql
+      DB_HOST: db
+      DB_PORT: '3306'
+      DB_DATABASE: lychee
+      DB_USERNAME: root
+      DB_PASSWORD: password
+    steps:
+      -
+        name: GET
+        run: 'curl -sSw "%{stderr}%{http_code}" http://localhost/ > /dev/null && curl -f http://localhost/'
+
+  docker-compose:
+    needs: multiarch
+    runs-on: ubuntu-latest
+    services:
+      lychee-docker:
+        image: lycheeorg/lychee:testing-${{ github.run_id }}
+        ports:
+          - 80:80
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set Password
+        run: "sed -i 's/<.*_PASSWORD>/password/g' docker-compose.yml"
+      -
+        name: Set Image
+        run: "sed -i 's|image: lycheeorg/lychee|image: lycheeorg/lychee:testing-${{ github.run_id }}|' docker-compose.yml"
+      -
+        name: Install docker-compose
+        run: "sudo apt install docker-compose"
+      -
+        name: Run docker-compose
+        run: 'docker-compose up -d && sleep 45 && docker-compose ps && curl -sSw "%{stderr}%{http_code}" http://localhost:90/ > /dev/null && curl -f http://localhost:90/'
+
+  retag:
+    needs: [default-env, sqlite, mysql, docker-compose]
+    runs-on: ubuntu-latest
+    container:
+      image: gcr.io/go-containerregistry/crane:debug
+    steps:
+      -
+        name: Retag image
+        run: |
+          crane auth login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }} index.docker.io
+          crane tag lycheeorg/lychee:testing-${{ github.run_id }} alpha

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -1,7 +1,12 @@
-name: Build and Push Alpha
+name: Build and Push branch
 
 on:
   workflow_dispatch:
+    inputs:
+      branchname:
+        description: 'Branch name'
+        required: true
+        default: 'alpha'
 
 env:
   PUID: '1000'
@@ -36,7 +41,7 @@ jobs:
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
           build-args: |
-            BRANCH=alpha
+            BRANCH=${{ github.event.inputs.branchname }}
           tags: |
             lycheeorg/lychee:testing-${{ github.run_id }}
 
@@ -128,4 +133,4 @@ jobs:
         name: Retag image
         run: |
           crane auth login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }} index.docker.io
-          crane tag lycheeorg/lychee:testing-${{ github.run_id }} alpha
+          crane tag lycheeorg/lychee:testing-${{ github.run_id }} ${{ github.event.inputs.branchname }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ ENV PHP_TZ=UTC
 ARG TARGET=dev
 # To install composer development dependencies, pass `--build-arg COMPOSER_NO_DEV=0` to `docker build`
 ARG COMPOSER_NO_DEV=1
+# To use the latest Lychee branch instead of master pass `docker build`
+ARG BRANCH=master
 
 # Install base dependencies, add user and group, clone the repo and install php libraries
 RUN \
@@ -51,13 +53,14 @@ RUN \
     adduser --gecos '' --no-create-home --disabled-password --uid "$PUID" --gid "$PGID" "$USER" && \
     cd /var/www/html && \
     if [ "$TARGET" = "release" ] ; then RELEASE_TAG="-b v$(curl -s https://raw.githubusercontent.com/LycheeOrg/Lychee/master/version.md)" ; fi && \
+    if [ "$BRANCH" != "master" ] ; then RELEASE_TAG="-b $BRANCH" ; fi && \
     git clone --depth 1 $RELEASE_TAG https://github.com/LycheeOrg/Lychee.git && \
-    mv Lychee/.git/refs/heads/master Lychee/master || cp Lychee/.git/HEAD Lychee/master && \
+    mv Lychee/.git/refs/heads/$BRANCH Lychee/$BRANCH || cp Lychee/.git/HEAD Lychee/$BRANCH && \
     mv Lychee/.git/HEAD Lychee/HEAD && \
     rm -r Lychee/.git/* && \
     mkdir -p Lychee/.git/refs/heads && \
     mv Lychee/HEAD Lychee/.git/HEAD && \
-    mv Lychee/master Lychee/.git/refs/heads/master && \
+    mv Lychee/$BRANCH Lychee/.git/refs/heads/$BRANCH && \
     echo "$TARGET" > /var/www/html/Lychee/docker_target && \
     cd /var/www/html/Lychee && \
     echo "Last release: $(cat version.md)" && \

--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ The following tags are available :
 
 * `latest`: Latest Lychee release
 * `v[NUMBER]`: Stable version tag for a Lychee release
-* `nightly` (also `dev`): Current master branch tag (Lychee operates on a stable master, so this should usually be safe)
+* `nightly` (also `dev`): Current master branch tag (Lychee operates on a stable master, so this should usually be safe.)
 * `devtools`: As above, but includes development dependencies
 * `testing`: Tag for testing new branches and pull requests. Designed for internal use by LycheeOrg.
+* `alpha`: Current alpha branch tag. (This branch contains bleeding edge changes but are not peer-reviewed.)
+* `alpha-devops`: As above, but includes development dependencies
 
 ## Setup
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,8 @@ set -e
 
 # Read Last commit hash from .git
 # This prevents installing git, and allows display of commit
-read -r longhash < /var/www/html/Lychee/.git/refs/heads/master
+branch=$(echo $(ls /var/www/html/Lychee/.git/refs/heads))
+read -r longhash < /var/www/html/Lychee/.git/refs/heads/$branch
 shorthash=$(echo $longhash |cut -c1-7)
 lycheeversion=$(</var/www/html/Lychee/version.md)
 target=$(</var/www/html/Lychee/docker_target)
@@ -21,6 +22,7 @@ echo '
 -------------------------------------
 Lychee Version: '$lycheeversion' ('$target')
 Lychee Commit:  '$shorthash'
+Lychee Branch:  '$branch'
 https://github.com/LycheeOrg/Lychee/commit/'$longhash'
 -------------------------------------'
 


### PR DESCRIPTION
Not that it would be used a lot, but it makes it easier to have an alpha build different than the master branch.
Allow to create a docker build of a specific branch for further testing.