### PR TITLE
Make LYCHEE_UPLOADS configurable by environment variable

### DIFF
--- a/inject.sh
+++ b/inject.sh
@@ -61,6 +61,9 @@ if [ "$DB_LOG_SQL_EXPLAIN" != '' ]; then
 if [ "$TIMEZONE" != '' ]; then
     replace_or_insert "TIMEZONE" "$TIMEZONE"
  fi
+if [ "$LYCHEE_UPLOADS" != '' ]; then
+    replace_or_insert "LYCHEE_UPLOADS" "$LYCHEE_UPLOADS"
+ fi
 if [ "$ENABLE_TOKEN_AUTH" != '' ]; then
     replace_or_insert "ENABLE_TOKEN_AUTH" "$ENABLE_TOKEN_AUTH"
  fi


### PR DESCRIPTION
I've been trying to get Lychee set up on https://fly.io, and almost everything I needed for a basic setup is configurable with just the out of the box docker image and env variables, except changing the location of the uploads directory. This PR adds `LYCHEE_UPLOADS` to the `inject.sh` script so that it can be configurable from an environment variable.