### PR TITLE
Change imagick configuration to allow pdf processing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,7 @@ ARG COMPOSER_NO_DEV=1
 # This is NOT compatible with the release target above
 ARG BRANCH=master
 
-# https://stackoverflow.com/questions/53377176/change-imagemagick-policy-on-a-dockerfile
-ARG IMAGEMAGIC_CONFIG=/etc/ImageMagick-6/policy.xml
-
+# https://stackoverflow.com/questions/53377176/change-imagemagick-policy-on-a-dockerfile (for the sed on policy.xml)
 # Install base dependencies, add user and group, clone the repo and install php libraries
 RUN \
     set -ev && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ ARG COMPOSER_NO_DEV=1
 # This is NOT compatible with the release target above
 ARG BRANCH=master
 
+# https://stackoverflow.com/questions/53377176/change-imagemagick-policy-on-a-dockerfile
+ARG IMAGEMAGIC_CONFIG=/etc/ImageMagick-6/policy.xml
+
 # Install base dependencies, add user and group, clone the repo and install php libraries
 RUN \
     set -ev && \
@@ -57,10 +60,12 @@ RUN \
     webp \
     cron \
     composer \
+    ghostscript \
     unzip && \
     addgroup --gid "$PGID" "$USER" && \
     adduser --gecos '' --no-create-home --disabled-password --uid "$PUID" --gid "$PGID" "$USER" && \
     cd /var/www/html && \
+    if [ -f "$IMAGEMAGIC_CONFIG" ] ; then sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' $IMAGEMAGIC_CONFIG ; else echo "did not see file $IMAGEMAGIC_CONFIG" ; fi && \
     if [ "$TARGET" = "release" ] ; then RELEASE_TAG="-b v$(curl -s https://raw.githubusercontent.com/LycheeOrg/Lychee/master/version.md)" ; \
     elif [ "$BRANCH" != "master" ] ; then RELEASE_TAG="-b $BRANCH" ; fi && \
     git clone --depth 1 $RELEASE_TAG https://github.com/LycheeOrg/Lychee.git && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN \
     addgroup --gid "$PGID" "$USER" && \
     adduser --gecos '' --no-create-home --disabled-password --uid "$PUID" --gid "$PGID" "$USER" && \
     cd /var/www/html && \
-    if [ -f "$IMAGEMAGIC_CONFIG" ] ; then sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' $IMAGEMAGIC_CONFIG ; else echo "did not see file $IMAGEMAGIC_CONFIG" ; fi && \
+    sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' /etc/ImageMagick-6/policy.xml && \
     if [ "$TARGET" = "release" ] ; then RELEASE_TAG="-b v$(curl -s https://raw.githubusercontent.com/LycheeOrg/Lychee/master/version.md)" ; \
     elif [ "$BRANCH" != "master" ] ; then RELEASE_TAG="-b $BRANCH" ; fi && \
     git clone --depth 1 $RELEASE_TAG https://github.com/LycheeOrg/Lychee.git && \


### PR DESCRIPTION
This pull request introduces changes to the `Dockerfile` to enhance support for handling PDF files with ImageMagick and includes the addition of a new dependency. The key updates involve configuring ImageMagick's policy settings and adding Ghostscript for improved PDF processing.

### ImageMagick Configuration Updates:
* Added a new `ARG IMAGEMAGIC_CONFIG` to specify the path to the ImageMagick policy file (`/etc/ImageMagick-6/policy.xml`). This allows for dynamic configuration of ImageMagick policies.
* Updated the `RUN` command to modify the ImageMagick policy file, enabling `read|write` rights for PDF processing. A fallback message is added if the policy file is not found.

### Dependency Additions:
* Added `ghostscript` to the list of installed packages to support PDF-related operations.