### PR TITLE
Fix path being added to query string

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -55,13 +55,6 @@ http {
         
         index index.php;
 
-        # serve static files directly
-        location ~* \.(jpg|jpeg|gif|css|png|js|ico|html)$ {
-            access_log off;
-            expires max;
-            log_not_found off;
-        }
-
         location = /favicon.ico {
             access_log off;
             log_not_found off;

--- a/default.conf
+++ b/default.conf
@@ -49,13 +49,25 @@ http {
     server {
         root /var/www/html/Lychee/public;
         listen       80;
+        listen       [::]:80;
         server_name  localhost;
         client_max_body_size 100M;
         
+        index index.php;
+
         # serve static files directly
         location ~* \.(jpg|jpeg|gif|css|png|js|ico|html)$ {
             access_log off;
             expires max;
+            log_not_found off;
+        }
+
+        location = /favicon.ico {
+            access_log off;
+            log_not_found off;
+        }
+        location = /robots.txt  {
+            access_log off;
             log_not_found off;
         }
 
@@ -66,34 +78,25 @@ http {
         }
 
         # If the request is not for a valid file (image, js, css, etc.), send to bootstrap
-        if (!-e $request_filename)
-        {
-            rewrite ^/(.*)$ /index.php?/$1 last;
-            break;
-        }
-
         location / {
-            index  index.php
             try_files $uri $uri/ /index.php?$query_string;
         }
 
+        error_page 404 /index.php;
+
         # Serve /index.php through PHP
-        location = /index.php {
-            fastcgi_split_path_info ^(.+?\.php)(/.*)$;
-
-            try_files $uri $document_root$fastcgi_script_name =404;
-
+        location ~ ^/index\.php(/|$) {
             # Mitigate https://httpoxy.org/ vulnerabilities
             fastcgi_param HTTP_PROXY "";
 
-            fastcgi_pass unix:/run/php/php8.4-fpm.sock;
-            fastcgi_index index.php;
-            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            fastcgi_pass unix:/var/run/php/php8.4-fpm.sock;
+            fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
             fastcgi_param PHP_VALUE "post_max_size=100M
                 max_execution_time=3600
                 upload_max_filesize=100M
                 memory_limit=256M";
             fastcgi_param PATH /usr/local/bin:/usr/bin:/bin;
+            fastcgi_hide_header X-Powered-By;
             include fastcgi_params;
         }
 


### PR DESCRIPTION
This pull request updates the `default.conf` file for the web server configuration, focusing on improving compatibility, security, and maintainability. The most important changes include adding IPv6 support, refining static file handling, and improving PHP request processing.

### Compatibility improvements:
* Added support for IPv6 by including `listen [::]:80;` in the server block.

### Static file and request handling:
* Replaced the old static file handling block with more specific locations for `/favicon.ico` and `/robots.txt`, disabling access logs and "not found" logs for these files.
* Simplified the request routing logic by replacing the `if` condition with `try_files` in the root location block.

### PHP processing improvements:
* Updated the PHP fastcgi configuration to use `$realpath_root` for `SCRIPT_FILENAME` and added `fastcgi_hide_header X-Powered-By` to enhance security.
* Modified the `fastcgi_pass` directive to use the correct path (`/var/run/php/php8.4-fpm.sock`) for PHP-FPM.