### PR TITLE
Always use www-data user (Reassign to use PUID/PGID if specified)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ LABEL maintainer="lycheeorg"
 # Environment variables
 ENV PUID='1000'
 ENV PGID='1000'
-ENV USER='lychee'
 ENV PHP_TZ=UTC
 
 # Arguments
@@ -60,8 +59,6 @@ RUN \
     composer \
     ghostscript \
     unzip && \
-    addgroup --gid "$PGID" "$USER" && \
-    adduser --gecos '' --no-create-home --disabled-password --uid "$PUID" --gid "$PGID" "$USER" && \
     cd /var/www/html && \
     sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' /etc/ImageMagick-6/policy.xml && \
     if [ "$TARGET" = "release" ] ; then RELEASE_TAG="-b v$(curl -s https://raw.githubusercontent.com/LycheeOrg/Lychee/master/version.md)" ; \
@@ -83,6 +80,8 @@ RUN \
     rm    storage/framework/sessions/* 2> /dev/null || true && \
     rm    storage/framework/views/* 2> /dev/null || true && \
     rm    storage/logs/* 2> /dev/null || true && \
+    usermod -o -u "$PUID" "www-data" && \
+    groupmod -o -g "$PGID" "www-data" && \
     chown -R www-data:www-data /var/www/html/Lychee && \
     chmod -R g+ws storage/image-jobs || true && \
     chmod -R g+ws storage/livewire-tmp || true && \

--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ Some variables are specific to Docker, and the default values are :
 
 * `PUID=1000`
 * `PGID=1000`
-* `USER=lychee`
 * `PHP_TZ=UTC`
 * `STARTUP_DELAY=0`
 


### PR DESCRIPTION
This PR removes the `lychee` user from the Docker image and instead forces the www-data user to the provided `PUID`/`PGID`.

This was raised by Yoko on [Discord](https://discord.com/channels/1046911561366765598/1119912673367314462/1386689438800675061), who has also done some testing of this branch (using the `:www-data` on Docker Hub, built a few days ago).

It's possible this will break things, but it shouldn't. I guess the most likely hit would be users with a custom PUID/PGID who have `SKIP_PERMISSIONS_CHECKS` enabled, but even then this should be fine.